### PR TITLE
Adding authentication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,25 @@ version: 2
 jobs:
   build:
     docker:
-    - image: node:8.10.0
+      - image: node:8.10.0
+        environment:
+          TAIGA_URL: http://localhost:8000
+      - image: postgres:11-alpine
+        environment:
+          POSTGRES_HOST: localhost
+          POSTGRES_DB: taiga
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+      - image: dockertaiga/back
+        environment:
+          POSTGRES_HOST: localhost
+          POSTGRES_DB: taiga
+          TAIGA_SCHEME: http
+          TAIGA_BACK_HOST: back
+          TAIGA_FRONT_HOST: front
+          EVENTS_HOST: events
+          TAIGA_SECRET: secret
+          ENABLE_SSL: false
 
     working_directory: ~/repo
 
@@ -10,12 +28,17 @@ jobs:
     - checkout
 
     - run:
+        name: install dockerize
+        command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+        environment:
+          DOCKERIZE_VERSION: v0.3.0
+    
+    - run:
         command: |
           npm install -g zapier-platform-cli
           npm install
+          dockerize -wait tcp://localhost:8000 -timeout 3m
           zapier test
-
-
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .env
 .idea
 .zapierapprc
+conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:8.10
+
+WORKDIR /app
+
+RUN npm install -g zapier-platform-cli
+
+COPY ./package.json .
+RUN npm install

--- a/authentication.js
+++ b/authentication.js
@@ -1,0 +1,51 @@
+const taigaHostUrl = process.env.TAIGA_URL;
+
+const testAuth = (z /*, bundle*/) => {
+  const promise = z.request({
+    url: taigaHostUrl + '/api/v1/users/me'
+  });
+
+  return promise.then((response) => {
+    if (response.status === 401) {
+      throw new Error('The Session Key you supplied is invalid');
+    }
+    return response;
+  });
+};
+
+const getSessionKey = (z, bundle) => {
+  const promise = z.request({
+    method: 'POST',
+    url: taigaHostUrl + '/api/v1/auth',
+    body: {
+      username: bundle.authData.username,
+      password: bundle.authData.password,
+      type: 'normal'
+    }
+  });
+
+  return promise.then((response) => {
+    if (response.status === 401) {
+      throw new Error('The username/password you supplied is invalid');
+    }
+    const json = JSON.parse(response.content);
+    return {
+      sessionKey: json.auth_token || null
+    };
+  });
+};
+
+module.exports = {
+  type: 'session',
+  fields: [
+    {key: 'username', label: 'Username', required: true, type: 'string'},
+    {key: 'password', label: 'Password', required: true, type: 'password'}
+  ],
+  test: {
+    url: taigaHostUrl + '/api/v1/users/me'
+  },
+  sessionConfig: {
+    perform: getSessionKey
+  },
+  connectionLabel: '{{username}}'
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+
+services:
+  taiga:
+    image: dockertaiga/back
+    depends_on:
+      - db
+    env_file:
+      - docker-vars.env
+  taiga-zap:
+    build: .
+    stdin_open: true
+    tty: true
+    volumes:
+      - ./:/app/
+  db:
+    image: postgres:11-alpine
+    ports:
+      - "5432:5432"
+    env_file:
+      - docker-vars.env

--- a/docker-vars.env
+++ b/docker-vars.env
@@ -1,0 +1,24 @@
+TAIGA_HOST=taiga.lan
+TAIGA_SCHEME=http
+TAIGA_BACK_HOST=back
+TAIGA_FRONT_HOST=front
+EVENTS_HOST=events
+TAIGA_SECRET=secret
+
+TAIGA_URL=http://taiga
+
+ENABLE_SSL=no
+# CERT_NAME=fullchain.pem
+# CERT_KEY=privkey.pem
+
+POSTGRES_HOST=db
+POSTGRES_DB=taiga
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+
+RABBIT_HOST=rabbit
+RABBIT_USER=taiga
+RABBIT_PASSWORD=password
+RABBIT_VHOST=taiga
+
+STARTUP_TIMEOUT=15s

--- a/index.js
+++ b/index.js
@@ -1,3 +1,15 @@
+const authentication = require('./authentication')
+
+const includeSessionKeyHeader = (request, z, bundle) => {
+  const sessionKey = bundle.sessionKey || bundle.authData.sessionKey;
+  console.log(sessionKey);
+  if (sessionKey) {
+    request.headers = request.headers || {};
+    request.headers['Authorization'] = "Bearer " + sessionKey;
+  }
+  return request;
+};
+
 // We can roll up all our behaviors in an App.
 const App = {
   // This is just shorthand to reference the installed dependencies you have. Zapier will
@@ -5,23 +17,13 @@ const App = {
   version: require('./package.json').version,
   platformVersion: require('zapier-platform-core').version,
 
-  // beforeRequest & afterResponse are optional hooks into the provided HTTP client
-  beforeRequest: [],
-
+  authentication: authentication,
+  beforeRequest: [includeSessionKeyHeader],
   afterResponse: [],
-
-  // If you want to define optional resources to simplify creation of triggers, searches, creates - do that here!
   resources: {},
-
-  // If you want your trigger to show up, you better include it here!
   triggers: {},
-
-  // If you want your searches to show up, you better include it here!
   searches: {},
-
-  // If you want your creates to show up, you better include it here!
   creates: {}
 };
 
-// Finally, export the app.
 module.exports = App;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,393 @@
+{
+  "name": "zapier-platform-example-app-minimal",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "8.10.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.20.tgz",
+      "integrity": "sha512-M7x8+5D1k/CuA6jhiwuSCmE8sbUWJF0wYsjcig9WrXvwUI5ArEoUBdOXpV4JcEMrLp02/QbDjw+kI+vQeKyQgg==",
+      "optional": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "dotenv": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.25"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.4",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "jsonschema": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.1.1.tgz",
+      "integrity": "sha1-PO3o4+QR03eHLu+8n98mODy8Ptk="
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "mime-db": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
+      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
+    },
+    "mime-types": {
+      "version": "2.1.25",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
+      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+      "requires": {
+        "mime-db": "1.42.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+    },
+    "should": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+      "dev": true,
+      "requires": {
+        "should-equal": "2.0.0",
+        "should-format": "3.0.3",
+        "should-type": "1.4.0",
+        "should-type-adaptors": "1.1.0",
+        "should-util": "1.0.1"
+      }
+    },
+    "should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0"
+      }
+    },
+    "should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0",
+        "should-type-adaptors": "1.1.0"
+      }
+    },
+    "should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+      "dev": true
+    },
+    "should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "requires": {
+        "should-type": "1.4.0",
+        "should-util": "1.0.1"
+      }
+    },
+    "should-util": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "3.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "zapier-platform-core": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/zapier-platform-core/-/zapier-platform-core-8.4.2.tgz",
+      "integrity": "sha512-S1bcTqp4TpYVEwyZCE0oCPB+sU6jdoIKjnLAcMW8Ciw2ULUjc30BzE1LSK+odOwUswxFcn5nkqWwOX0yDfIDXg==",
+      "requires": {
+        "@types/node": "8.10.20",
+        "bluebird": "3.5.0",
+        "content-disposition": "0.5.2",
+        "dotenv": "5.0.1",
+        "form-data": "2.3.2",
+        "lodash": "4.17.15",
+        "node-fetch": "1.7.1",
+        "oauth-sign": "0.9.0",
+        "semver": "5.6.0",
+        "zapier-platform-schema": "8.4.2"
+      }
+    },
+    "zapier-platform-schema": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/zapier-platform-schema/-/zapier-platform-schema-8.4.2.tgz",
+      "integrity": "sha512-HhXiV5mXPWjq/iTsCZDlxMGxR5q/7+evudeEEDxlk8yEy3d5uKE+b8IqSs5eJ4X99eO8jTBWwdiZqiOr4J95tQ==",
+      "requires": {
+        "jsonschema": "1.1.1",
+        "lodash": "4.17.15"
+      }
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,21 +1,39 @@
-/* globals describe, it */
-
 require('should');
 
-// Uncomment and use this to make test calls into your app:
+const zapier = require('zapier-platform-core');
+const App = require('../index');
+const appTester = zapier.createAppTester(App);
 
-// const zapier = require('zapier-platform-core');
-// const App = require('../index');
-// const appTester = zapier.createAppTester(App);
+describe('session auth app', () => {
+    it('has an exchange for username/password', (done) => {
+      const bundle = {
+        authData: {
+          username: 'admin',
+          password: '123123'
+        }
+      };
+  
+      appTester(App.authentication.sessionConfig.perform, bundle)
+        .then((newAuthData) => {
+          should(newAuthData.sessionKey).not.eql(null);
+          done();
+        })
+        .catch(done);
+    });
 
-describe('My App', () => {
-  it('should test something', done => {
-    const x = 1;
-    x.should.eql(1);
+    it('has returns null for invalid login', (done) => {
+        const bundle = {
+            authData: {
+              username: 'non-existent-user',
+              password: 'some-password'
+            }
+          };
 
-    // const bundle = { inputData: {} };
-    // const results = appTester(App.triggers.SOME_TRIGGER.operation.perform, bundle);
-    // results.length.should.eql(3);
-    done();
-  });
+          appTester(App.authentication.sessionConfig.perform, bundle)
+          .then((newAuthData) => {
+            should(newAuthData.sessionKey).eql(null);
+            done();
+          })
+          .catch(done);
+    });
 });


### PR DESCRIPTION
Taiga uses a session based auth where we need to pass in:
 - username
 - password
 - type: 'normal'

This returns an `auth` object that contains an `auth_token`, which
can be used for further authentications.
We use the `beforeRequest` hook to construct the proper `Authorization`
header.

This commit also contains a complete dockerised setup that we can use to
run tests against a `Taiga backend`. This works both locally and in
CircleCI.

To run locally:
```
docker-compose up
docker-compose exec zapier
cd ./app
zapier test
```

Note: if you're planning to run the cluster without docker, make sure to
export the variables found in `docker-vars.env`.